### PR TITLE
#10 makeコマンドの修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ stop:
 	docker-compose stop
 
 db_:
-	docker-compose run web bundle exec rails db:create db:migrate
+	docker-compose exec web rails db:create db:migrate
 
 down:
 	docker-compose down -v

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ stop:
 	docker-compose stop
 
 db_:
-	docker-compose run web rails db:create db:migrate
+	docker-compose run web bundle exec rails db:create db:migrate
 
 down:
 	docker-compose down -v

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ make build
 make up
 ```
 
-dbの作成
+dbの作成、マイグレーションの実行
+※コンテナが立ち上がっていることを確認する。
 
 ```
 make db_
@@ -90,4 +91,3 @@ issue#1 モデルの作成の場合
 
 例）
 `git commit -m '#1 add: modelの作成' `
-


### PR DESCRIPTION
# Pull Request

<!-- Pull Requestのタイトル -->
makeコマンドの修正
## PRタイプ

<!-- Pull Requestの種類を選択 -->
<!-- 必要なものだけ残す -->

* 🧹リファクタリング
* 📖ドキュメント整備
* 💻開発環境

## 変更内容
お疲れ様です。
READMEに書いてある一部手順とMakefileを修正しました。

dbの作成、マイグレーションの実行を行うmake db_コマンドですが

Makefileに
```
docker-compose run  …
```
の記載を

```
docker-compose exec …
```

に変更しました。

runとexecの違いですが

run　再度コンテナを立ち上げるコマンドの実行
exec　実行中のコンテナに対してのコマンドの実行
といった違いがあり不要なコンテナまで立ち上げてしまいます。


バックグラウンドで立ち上げずにログが出てる画面で
Ctrl + Cでコンテナ自体を止めることはできますが、
不要なコンテナが残ってしまうみたいなので、
ターミナル上でmake downを入力するようお願いします。


## ※必要の場合 確認方法

<!-- 行った修正をレビュアーが確認するための手順を記載しましょう。例えば以下のように。-->
<!-- Gem を追加したので docker-compose run web bundle install を実行してください -->
<!-- カラムを追加したので docker-compose run web bundle exec rails db:migrate を実行してください -->

**ターミナル上でコンテナの立ち上げ**

dbとrailsのコンテナ立ち上がったことを確認する。
```
make up
```

dbの作成、およびマイグレーション
```
make db_
```
dbとrailsのコンテナ立ち上がったことを確認する。
[![Image from Gyazo](https://i.gyazo.com/0fcf9e928386ea300c7285d80ae12069.jpg)](https://gyazo.com/0fcf9e928386ea300c7285d80ae12069)


## レビュワーへの注意点・相談内容・懸念点
一度ローカルで確認して頂いて問題なく立ち上がり、不要なコンテナが生成されていないことを
確認していただければ幸いです。
run --rmコマンドでもいいかなって思いましたが、再度コンテナを立ち上げる必要がないため
Execにしました。

参考記事
https://qiita.com/soicchi/items/c307ca7042c136292925 

close #10 