### PR TITLE
Refactor error messages #41

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,7 +9,7 @@ class TasksController < ApplicationController
   def create
     @task = Task.new(task_params)
     if @task.save
-      redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+      redirect_to tasks_url, notice: "タスク「#{@task.name}」を登録しました。"
     else
       render :new
     end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -23,9 +23,12 @@ class TasksController < ApplicationController
   end
 
   def update
-    task = Task.find(params[:id])
-    task.update!(task_params)
-    redirect_to tasks_url, notice: "タスク 「#{task.name}」を更新しました。"
+    @task = Task.find(params[:id])
+    if @task.update(task_params)
+      redirect_to tasks_url, notice: "タスク 「#{@task.name}」を更新しました。"
+    else
+      render :edit
+    end
   end
 
   def destroy

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,9 +7,12 @@ class TasksController < ApplicationController
   end
 
   def create
-    task = Task.new(task_params)
-    task.save!
-    redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+    @task = Task.new(task_params)
+    if @task.save
+      redirect_to tasks_url, notice: "タスク「#{task.name}」を登録しました。"
+    else
+      render :new
+    end
   end
 
   def show

--- a/app/views/shared/_error_messages.html.slim
+++ b/app/views/shared/_error_messages.html.slim
@@ -1,0 +1,4 @@
+- if model.errors.any?
+  .alert.alert-danger
+    - model.errors.full_messages.each do |message|
+      li = message

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -4,6 +4,7 @@ h1 タスクの編集
   = link_to '一覧', tasks_path, class: 'nav-link'
 
 = form_with model: @task, local: true do |f|
+  = render 'shared/error_messages', model: f.object
   .form-group
     = f.label :name
     = f.text_field :name, class: 'form-control', id: 'task_name'

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -4,6 +4,7 @@ h1 タスクの新規登録
   = link_to '一覧', tasks_path, class: 'nav-link'
 
 = form_with model: @task, local: true do |f|
+  = render 'shared/error_messages', model: f.object
   .form-group
     = f.label :name
     = f.text_field :name, class: 'form-control', id: 'task_name'


### PR DESCRIPTION
# Pull Request
エラーメッセージの共通化
## PRタイプ
* 🆕新機能
* 🧹リファクタリング
## 変更内容
- _error_messages_html.slim を作成
- 複数のフォームで使用できるよう、renderの引数を`model: f.object`としました
- そのため、create / update アクションのtaskをインスタンス変数へ変更
- エラーメッセージを表示させるため、上記アクションをifで条件分岐させました

<img width="1512" alt="スクリーンショット 2023-01-26 0 27 00" src="https://user-images.githubusercontent.com/104258415/214604768-51867a68-1cb8-4609-a208-8570b8290f65.png">

## 確認方法

1. [新規作成画面](http://127.0.0.1:3000/tasks/new)にて、
名称を空欄のまま「登録する」ボタンを押し、エラーメッセージが表示されるかを確認してください。

2. [編集画面](http://127.0.0.1:3000/tasks/1/edit)にて、
名称を消去してから「登録する」ボタンを押し、エラーメッセージが表示されるかを確認してください。
## チェックリスト
- [x] Rspecをパスした
- [x] Rubocopをパスした
## レビュワーへの注意点・相談内容・懸念点
コントローラーを修正しているので、コンフリクトが起きるかもしれません。

close #41 